### PR TITLE
Fix make dev, missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
+    "pino-pretty": "^4.1.0",
     "tslint": "^5.11.0",
     "tslint-config-standard": "^8.0.1",
     "typescript": "^3.1.3"


### PR DESCRIPTION
When running `make dev`, the docker container `dev_walletconnect_node` errors and exits right away.

Adding the missing dependency to package.json fixes the problem and the dev bridge runs as expected.